### PR TITLE
IndexOf is Javascript 1.6, IN is 1.4

### DIFF
--- a/stringify.js
+++ b/stringify.js
@@ -8,10 +8,10 @@ function getSerialize (fn, decycle) {
   return function(key, value) {
     var ret = value;
     if (typeof value === 'object' && value) {
-      if (seen.indexOf(value) !== -1)
+      if (value in seen)
         ret = decycle(key, value);
       else
-        seen.push(value);
+        seen[value]=null;
     }
     if (fn) ret = fn(key, ret);
     return ret;


### PR DESCRIPTION
Given that IN is implemented on 1.4 and IE8 friendly (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in VS https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf), seems like it is even more performant.
This is a benchmark test I executed:

var Bench = require('bench');
var Stringify = require('./json-stringify-safe');
var StringifyIN = require('./stringify');

var list = [];
for (var i = 0; i < 1000; ++i ) { // tried 100, 1000, 10000
    list.push({'some' : 'thing' + i}); // tried 'some': 'thing' as well, but I wanted to test multiple values
}

exports.compare = {
    'safe stringify' : function () {

```
    return Stringify(list);
},
'safe stringify IN' : function () {

    return StringifyIN(list);
}
```

};
Bench.runMain();

This is what happens:

Please be patient.
{ http_parser: '1.0',
  node: '0.8.3',
  v8: '3.11.10.15',
  ares: '1.7.5-DEV',
  uv: '0.8',
  zlib: '1.2.3',
  openssl: '1.0.0f' }
Scores: (bigger is better)

safe stringify IN
Raw:

> 0.8130081300813008
> 0.8097165991902834
> 0.78064012490242
> 0.8110300081103001
> Average (mean) 0.8035987155710761

safe stringify
Raw:

> 0.21299254526091588
> 0.2114611968703743
> 0.21272069772388855
> 0.21249468763280918
> Average (mean) 0.212417281871997

Winner: safe stringify IN
Compared with next highest (safe stringify), it's:
73.57% faster
3.78 times as fast
0.58 order(s) of magnitude faster
QUITE A BIT FASTER
