### PR TITLE
Switch to a contextual stringification.

### DIFF
--- a/stringify.js
+++ b/stringify.js
@@ -1,35 +1,83 @@
 module.exports = stringify;
 
+function getObjectChildren(value) {
+  return Object.keys(value).filter(function (k) {
+    return typeof value[k] === 'object' && value[k];
+  });
+}
+
 function getSerialize (fn, decycle) {
-  var seen = [], keys = [];
+  var context;
   decycle = decycle || function(key, value) {
-    return '[Circular ' + getPath(value, seen, keys) + ']'
+    return '[Circular ' + getPath(value, context) + ']';
   };
+
+  // Drop all contexts that had all their object-like children checked.
+  var cleanContext = function () {
+    while (!context.children.length) {
+      context = context.parent;
+      if (!context) {
+        break;
+      }
+    }
+  };
+
   return function(key, value) {
     var ret = value;
     if (typeof value === 'object' && value) {
-      if (seen.indexOf(value) !== -1)
-        ret = decycle(key, value);
-      else {
-        seen.push(value);
-        keys.push(key);
+      if (context) {
+        // Remove the child we're currently processing
+        context.children.shift();
+
+        if (context.seen.indexOf(value) !== -1) {
+          ret = decycle(key, value);
+
+          // That circular reference was also the last child to evaluate
+          if (!context.children.length) {
+            cleanContext();
+          }
+        } else {
+          // List all the direct children that are objects so that we know if we need to create a new context
+          var children = getObjectChildren(value);
+
+          if (children.length) {
+            context = {
+              parent: context,
+              key: key,
+              children: children,
+              seen: context.seen.concat([value])
+            };
+          } else {
+            // There are no more object child to match for circular references, we can pop the contexts
+            cleanContext();
+          }
+        }
+      } else {
+        // The initial context
+        context = {
+          key: key,
+          children: getObjectChildren(value),
+          seen: [value]
+        };
       }
     }
     if (fn) ret = fn(key, ret);
     return ret;
-  }
+  };
 }
 
-function getPath (value, seen, keys) {
-  var index = seen.indexOf(value);
-  var path = [ keys[index] ];
-  for (index--; index >= 0; index--) {
-    if (seen[index][ path[0] ] === value) {
-      value = seen[index];
-      path.unshift(keys[index]);
+function getPath (value, context) {
+  var path = '';
+
+  do {
+    if (context.parent && context.parent.seen.indexOf(value) === -1) {
+      path = path ? context.key + '.' + path : context.key;
     }
-  }
-  return '~' + path.join('.');
+
+    context = context.parent;
+  } while (context);
+
+  return '~' + (path ? '.' + path : path);
 }
 
 function stringify(obj, fn, spaces, decycle) {

--- a/test.js
+++ b/test.js
@@ -110,11 +110,23 @@ var multi = {
     },
     {
       "x": 2,
-      "a": "[Circular ~.list.0]"
+      "a": {
+        "x": 1,
+        "a": "[Circular ~.list.1.a]"
+      }
     },
     {
-      "a": "[Circular ~.list.0]",
-      "b": "[Circular ~.list.1]"
+      "a": {
+        "x": 1,
+        "a": "[Circular ~.list.2.a]"
+      },
+      "b": {
+        "x": 2,
+        "a": {
+          "x": 1,
+          "a": "[Circular ~.list.2.b.a]"
+        }
+      }
     }
   ],
   "d": "[Circular ~]"
@@ -122,6 +134,13 @@ var multi = {
 
 assert.equal(JSON.stringify(multi, null, 2),
              stringify(d, null, 2));
+
+////////////////////
+// independent trees
+var obj = { foo: 'bar' };
+testObj = {"a":{"foo":"bar"},"b":{"foo":"bar"}};
+assert.equal(JSON.stringify(testObj, null, 2),
+             stringify({ a: obj, b: obj }, null, 2));
 
 ////////
 // pass!


### PR DESCRIPTION
This should fix #9.

It's a big change but the simple `seen` array doesn't allow for ancestors check so I had to create a context that evolves as it goes through the properties.

Also an existing test was wrong on its expectations so I had to fix that.
