### PR TITLE
Performance improvement

### DIFF
--- a/stringify.js
+++ b/stringify.js
@@ -16,8 +16,14 @@ function serializer(replacer, cycleReplacer) {
   return function(key, value) {
     if (stack.length > 0) {
       var thisPos = stack.indexOf(this)
-      ~thisPos ? stack.splice(thisPos + 1) : stack.push(this)
-      ~thisPos ? keys.splice(thisPos, Infinity, key) : keys.push(key)
+      if (~thisPos) {
+        stack.length = thisPos + 1
+        keys.length = thisPos + 1
+        keys[thisPos] = key
+      } else {
+        stack.push(this)
+        keys.push(key)
+      }
       if (~stack.indexOf(value)) value = cycleReplacer.call(this, key, value)
     }
     else stack.push(value)


### PR DESCRIPTION
This code is consistently faster on all runs that I've made.
Worst case was :

```
{ http_parser: '2.6.2',
  node: '5.7.0',
  v8: '4.6.85.31',
  uv: '1.8.0',
  zlib: '1.2.8',
  ares: '1.10.1-DEV',
  icu: '56.1',
  modules: '47',
  openssl: '1.0.2f' }
Scores: (bigger is better)

alt
Raw:
 > 4.9603174603174605
 > 5.185825410544512
 > 4.344048653344918
 > 4.273504273504273
Average (mean) 4.69092394942779

jss
Raw:
 > 1.6963528413910094
 > 1.7226528854435832
 > 1.5873015873015872
 > 1.8796992481203008
Average (mean) 1.7215016405641201

Winner: alt
Compared with next highest (jss), it's:
63.3% faster
2.72 times as fast
0.44 order(s) of magnitude faster
QUITE A BIT FASTER
```

The test was done with bench stringifying #16's example (a smaller version of it since it took too long).
