### PR TITLE
falsey values for replacer should be allowed

### DIFF
--- a/stringify.js
+++ b/stringify.js
@@ -22,6 +22,6 @@ function serializer(replacer, cycleReplacer) {
     }
     else stack.push(value)
 
-    return replacer == null ? value : replacer.call(this, key, value)
+    return !replacer ? value : replacer.call(this, key, value)
   }
 }


### PR DESCRIPTION
JSON.stringify is happy with falsey values for replacer and 0 is shorter than null